### PR TITLE
feat(ai-node): generic AI gateway with OpenRouter as default backend

### DIFF
--- a/ai-node/.env.local.example
+++ b/ai-node/.env.local.example
@@ -1,0 +1,34 @@
+# --- AI Gateway (default: OpenRouter) ---
+OPENROUTER_API_KEY=your_openrouter_api_key
+
+# AI gateway mode (optional)
+# AI_GATEWAY=openrouter   # default
+# AI_GATEWAY=native       # use native keys globally
+
+# Per-class overrides (optional)
+# OPENAI_CLASS_PROVIDER=native
+# ANTHROPIC_CLASS_PROVIDER=native
+# XAI_CLASS_PROVIDER=native
+# HYPERBOLIC_CLASS_PROVIDER=native
+
+# Optional per-class model override (OpenRouter or native)
+# OPENAI_CLASS_MODEL=openai/gpt-4o
+# ANTHROPIC_CLASS_MODEL=anthropic/claude-3-5-sonnet-20241022
+# XAI_CLASS_MODEL=x-ai/grok-4-0709
+# HYPERBOLIC_CLASS_MODEL=meta-llama/llama-3.3-70b-instruct
+
+# Legacy compatibility opt-in
+# AI_GATEWAY_LEGACY_NATIVE_FALLBACK=false
+
+# --- Advanced: Native Provider Overrides (optional) ---
+# Native keys are ONLY used when AI_GATEWAY=native or per-class override is set
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+XAI_API_KEY=
+HYPERBOLIC_API_KEY=
+
+# Existing app settings
+JUSTIFIER_MODEL=OpenAI:gpt-5-nano-2025-08-07
+REASONING_MODEL_MAX_TOKENS=16000
+MODEL_TIMEOUT_MS=120000
+REQUEST_TIMEOUT_MS=240000

--- a/ai-node/DESIGN-OPENROUTER-GATEWAY.md
+++ b/ai-node/DESIGN-OPENROUTER-GATEWAY.md
@@ -1,0 +1,37 @@
+# DESIGN — OpenRouter Gateway Routing
+
+## Routing owner
+
+Routing decisions are centralized in:
+- `src/lib/llm/provider-config.ts`
+
+Provider construction is in:
+- `src/lib/llm/llm-factory.ts`
+
+OpenRouter implementation is in:
+- `src/lib/llm/openrouter-provider.ts`
+
+## Precedence table
+
+| Priority | Source | Example | Result |
+|---|---|---|---|
+| 1 | Per-class override | `OPENAI_CLASS_PROVIDER=native` | class uses native |
+| 2 | Global override | `AI_GATEWAY=openrouter\|native` | all non-ollama classes follow mode |
+| 3 | Legacy opt-in | `AI_GATEWAY_LEGACY_NATIVE_FALLBACK=true` + native key | class uses native |
+| 4 | Default | none above | class uses OpenRouter |
+
+Special case:
+- `ollama` is always native/local.
+
+Safety behavior:
+- Presence of native keys alone does **not** auto-activate native mode.
+- If `OPENROUTER_API_KEY` is missing and native key exists, class falls back to native with warning.
+
+## Runtime observability
+
+`/api/health` includes:
+- `ai_gateway.mode`
+- `ai_gateway.openrouterConfigured`
+- per-class routing list with backend/model/reason
+
+This allows operators to verify effective routing without inspecting source code.

--- a/ai-node/MIGRATION.md
+++ b/ai-node/MIGRATION.md
@@ -1,0 +1,52 @@
+# MIGRATION — OpenRouter Gateway Default
+
+## What changed
+
+The AI node now uses a gateway abstraction where provider classes (`OpenAI`, `Anthropic`, `xAI`, `Hyperbolic`) route through OpenRouter by default.
+
+Ollama remains local-only and always uses native/local routing.
+
+## Why
+
+- One default integration path
+- Easier operator setup
+- Centralized model routing logic
+- Keeps native providers available as explicit opt-in paths
+
+## Backward compatibility
+
+Existing installs with native provider keys continue to work.
+
+Behavior is:
+1. Per-class override (`<CLASS>_CLASS_PROVIDER`)
+2. Global override (`AI_GATEWAY`)
+3. Legacy native opt-in (`AI_GATEWAY_LEGACY_NATIVE_FALLBACK=true` + native key present)
+4. Default: OpenRouter
+
+If `OPENROUTER_API_KEY` is missing and a native key exists for that class, gateway logs a warning and falls back to native for that class.
+
+## How to migrate
+
+### Recommended (default)
+Set:
+- `OPENROUTER_API_KEY`
+
+Optional:
+- `AI_GATEWAY=openrouter`
+
+### Keep native-only behavior explicitly
+Set:
+- `AI_GATEWAY=native`
+- corresponding native keys (`OPENAI_API_KEY`, etc.)
+
+### Mixed mode
+Set global `AI_GATEWAY=openrouter` and override selected classes:
+- `OPENAI_CLASS_PROVIDER=native`
+- `ANTHROPIC_CLASS_PROVIDER=native`
+
+## Justifier model
+`JUSTIFIER_MODEL` format remains supported:
+- `Provider:model-name`
+
+Example:
+- `OpenAI:gpt-5-nano-2025-08-07`

--- a/ai-node/README.md
+++ b/ai-node/README.md
@@ -319,6 +319,39 @@ The text extraction system can be configured via environment variables or progra
 - Failed/unsupported attachments are skipped with console warnings
 - Image attachments bypass text extraction and are sent directly
 
+## AI Gateway (OpenRouter default)
+
+The AI node now routes provider classes through an AI gateway abstraction.
+
+Default behavior:
+- `OpenAI`, `Anthropic`, `xAI`, and `Hyperbolic` classes use **OpenRouter** by default.
+- `Ollama` remains local-only/native.
+
+Required for default path:
+
+```env
+OPENROUTER_API_KEY=your_openrouter_api_key
+```
+
+Override controls:
+
+```env
+# Global
+AI_GATEWAY=openrouter   # default
+# AI_GATEWAY=native
+
+# Per-class
+# OPENAI_CLASS_PROVIDER=native
+# ANTHROPIC_CLASS_PROVIDER=native
+# XAI_CLASS_PROVIDER=native
+# HYPERBOLIC_CLASS_PROVIDER=native
+```
+
+Important:
+- Native keys being present in env do **not** auto-enable native mode.
+- Native mode is used only with explicit override (`AI_GATEWAY=native` or per-class override),
+  except fallback behavior when `OPENROUTER_API_KEY` is missing and a class has a native key.
+
 ## Additional Environment Variables
 
 For the rank-and-justify feature, you may configure an additional environment variable:

--- a/ai-node/src/__tests__/api/health.test.ts
+++ b/ai-node/src/__tests__/api/health.test.ts
@@ -1,0 +1,86 @@
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn((data: any) => ({
+      json: jest.fn().mockResolvedValue(data),
+    })),
+  },
+}));
+
+import { NextResponse } from 'next/server';
+import { GET } from '../../app/api/health/route';
+
+describe('GET /api/health', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.AI_GATEWAY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_CLASS_PROVIDER;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test('returns ok status with ai_gateway section', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-key';
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.status).toBe('ok');
+    expect(body.ai_gateway).toBeDefined();
+    expect(body.ai_gateway.openrouterConfigured).toBe(true);
+  });
+
+  test('ai_gateway.routing includes all provider classes', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-key';
+
+    const response = await GET();
+    const body = await response.json();
+
+    const classes = body.ai_gateway.routing.map((r: any) => r.class);
+    expect(classes).toEqual(expect.arrayContaining(['openai', 'anthropic', 'xai', 'hyperbolic', 'ollama']));
+  });
+
+  test('ollama always shows native backend', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-key';
+
+    const response = await GET();
+    const body = await response.json();
+
+    const ollama = body.ai_gateway.routing.find((r: any) => r.class === 'ollama');
+    expect(ollama.backend).toBe('native');
+  });
+
+  test('non-ollama classes default to openrouter when key is set', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-key';
+
+    const response = await GET();
+    const body = await response.json();
+
+    const openai = body.ai_gateway.routing.find((r: any) => r.class === 'openai');
+    expect(openai.backend).toBe('openrouter');
+  });
+
+  test('reflects native override in routing', async () => {
+    process.env.AI_GATEWAY = 'native';
+    process.env.OPENAI_API_KEY = 'native-key';
+
+    const response = await GET();
+    const body = await response.json();
+
+    const openai = body.ai_gateway.routing.find((r: any) => r.class === 'openai');
+    expect(openai.backend).toBe('native');
+  });
+
+  test('shows openrouterConfigured false when key is missing', async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.ai_gateway.openrouterConfigured).toBe(false);
+  });
+});

--- a/ai-node/src/__tests__/lib/llm/anthropic-provider.test.ts
+++ b/ai-node/src/__tests__/lib/llm/anthropic-provider.test.ts
@@ -52,6 +52,8 @@ describe('AnthropicProvider', () => {
     expect(ChatAnthropic).toHaveBeenCalledWith({
       anthropicApiKey: 'test-anthropic-api-key',
       modelName: 'claude-2.1',
+      temperature: 0.7,
+      topP: undefined,
     });
     expect(mockInvoke).toHaveBeenCalledWith('Test prompt');
   });
@@ -72,6 +74,8 @@ describe('AnthropicProvider', () => {
     expect(ChatAnthropic).toHaveBeenCalledWith({
       anthropicApiKey: 'test-anthropic-api-key',
       modelName: 'claude-3-sonnet-20240229',
+      temperature: 0.7,
+      topP: undefined,
     });
     expect(mockInvoke).toHaveBeenCalledWith([{
       role: "user",
@@ -122,6 +126,8 @@ describe('AnthropicProvider', () => {
     expect(ChatAnthropic).toHaveBeenCalledWith({
       anthropicApiKey: 'test-anthropic-api-key',
       modelName: 'claude-3-5-sonnet-20241022',
+      temperature: 0.7,
+      topP: undefined,
     });
     expect(mockInvoke).toHaveBeenCalledWith([{
       role: "user",

--- a/ai-node/src/__tests__/lib/llm/llm-factory.test.ts
+++ b/ai-node/src/__tests__/lib/llm/llm-factory.test.ts
@@ -88,4 +88,15 @@ describe('LLMFactory gateway routing', () => {
 
     expect(OpenAIProvider).toHaveBeenCalled();
   });
+
+  test('falls back to native when OPENROUTER_API_KEY missing and native key exists', async () => {
+    process.env.OPENAI_API_KEY = 'native-key';
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    await LLMFactory.getProvider('OpenAI');
+
+    expect(OpenAIProvider).toHaveBeenCalled();
+    expect(OpenRouterProvider).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });

--- a/ai-node/src/__tests__/lib/llm/llm-factory.test.ts
+++ b/ai-node/src/__tests__/lib/llm/llm-factory.test.ts
@@ -1,0 +1,91 @@
+jest.mock('../../../lib/llm/openrouter-provider', () => ({
+  OpenRouterProvider: jest.fn().mockImplementation(() => ({
+    initialize: jest.fn().mockResolvedValue(undefined),
+    getModels: jest.fn().mockResolvedValue([]),
+    generateResponse: jest.fn(),
+    generateResponseWithImage: jest.fn(),
+    generateResponseWithAttachments: jest.fn(),
+    supportsImages: jest.fn().mockReturnValue(true),
+    supportsAttachments: jest.fn().mockReturnValue(true),
+  })),
+}));
+
+jest.mock('../../../lib/llm/openai-provider', () => ({
+  OpenAIProvider: jest.fn().mockImplementation(() => ({ initialize: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../../lib/llm/anthropic-provider', () => ({
+  AnthropicProvider: jest.fn().mockImplementation(() => ({ initialize: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../../lib/llm/xai-provider', () => ({
+  XAIProvider: jest.fn().mockImplementation(() => ({ initialize: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../../lib/llm/hyperbolic-provider', () => ({
+  HyperbolicProvider: jest.fn().mockImplementation(() => ({ initialize: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../../lib/llm/ollama-provider', () => ({
+  OllamaProvider: jest.fn().mockImplementation(() => ({ initialize: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+import { LLMFactory } from '../../../lib/llm/llm-factory';
+import { OpenRouterProvider } from '../../../lib/llm/openrouter-provider';
+import { OpenAIProvider } from '../../../lib/llm/openai-provider';
+
+describe('LLMFactory gateway routing', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.AI_GATEWAY;
+    delete process.env.OPENAI_CLASS_PROVIDER;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.AI_GATEWAY_LEGACY_NATIVE_FALLBACK;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test('uses OpenRouter by default when OPENROUTER_API_KEY is present', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-key';
+
+    await LLMFactory.getProvider('OpenAI');
+
+    expect(OpenRouterProvider).toHaveBeenCalled();
+    expect(OpenAIProvider).not.toHaveBeenCalled();
+  });
+
+  test('uses native when AI_GATEWAY=native is set', async () => {
+    process.env.AI_GATEWAY = 'native';
+    process.env.OPENAI_API_KEY = 'native-key';
+
+    await LLMFactory.getProvider('OpenAI');
+
+    expect(OpenAIProvider).toHaveBeenCalled();
+    expect(OpenRouterProvider).not.toHaveBeenCalled();
+  });
+
+  test('per-class override beats global override in mixed mode', async () => {
+    process.env.AI_GATEWAY = 'openrouter';
+    process.env.OPENAI_CLASS_PROVIDER = 'native';
+
+    await LLMFactory.getProvider('OpenAI');
+
+    expect(OpenAIProvider).toHaveBeenCalled();
+    expect(OpenRouterProvider).not.toHaveBeenCalled();
+  });
+
+  test('legacy native opt-in fallback is still supported', async () => {
+    process.env.AI_GATEWAY_LEGACY_NATIVE_FALLBACK = 'true';
+    process.env.OPENAI_API_KEY = 'native-key';
+
+    await LLMFactory.getProvider('OpenAI');
+
+    expect(OpenAIProvider).toHaveBeenCalled();
+  });
+});

--- a/ai-node/src/__tests__/lib/llm/openrouter-provider.test.ts
+++ b/ai-node/src/__tests__/lib/llm/openrouter-provider.test.ts
@@ -1,0 +1,50 @@
+import { OpenRouterProvider } from '../../../lib/llm/openrouter-provider';
+
+describe('OpenRouterProvider', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    // @ts-ignore
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test('generateResponse sends OpenAI-compatible request', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok-from-openrouter' } }],
+      }),
+    });
+
+    const provider = new OpenRouterProvider();
+    const result = await provider.generateResponse('hello', 'openai/gpt-4o');
+
+    expect(result).toBe('ok-from-openrouter');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain('openrouter.ai/api/v1/chat/completions');
+    expect(init.headers.Authorization).toContain('Bearer or-test-key');
+  });
+
+  test('throws on non-ok response', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'unauthorized',
+    });
+
+    const provider = new OpenRouterProvider();
+
+    await expect(provider.generateResponse('hello', 'openai/gpt-4o')).rejects.toThrow('HTTP 401');
+  });
+});

--- a/ai-node/src/__tests__/lib/llm/openrouter-provider.test.ts
+++ b/ai-node/src/__tests__/lib/llm/openrouter-provider.test.ts
@@ -1,11 +1,23 @@
 import { OpenRouterProvider } from '../../../lib/llm/openrouter-provider';
 
+function mockFetchSuccess(content: string = 'ok-from-openrouter') {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      choices: [{ message: { content } }],
+    }),
+  });
+}
+
 describe('OpenRouterProvider', () => {
   const ORIGINAL_ENV = process.env;
 
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
     process.env.OPENROUTER_API_KEY = 'or-test-key';
+    delete process.env.DEFAULT_MAX_TOKENS;
+    delete process.env.REASONING_MODEL_MAX_TOKENS;
+    delete process.env.MODEL_TIMEOUT_MS;
     // @ts-ignore
     global.fetch = jest.fn();
   });
@@ -19,12 +31,7 @@ describe('OpenRouterProvider', () => {
   });
 
   test('generateResponse sends OpenAI-compatible request', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        choices: [{ message: { content: 'ok-from-openrouter' } }],
-      }),
-    });
+    mockFetchSuccess();
 
     const provider = new OpenRouterProvider();
     const result = await provider.generateResponse('hello', 'openai/gpt-4o');
@@ -46,5 +53,123 @@ describe('OpenRouterProvider', () => {
     const provider = new OpenRouterProvider();
 
     await expect(provider.generateResponse('hello', 'openai/gpt-4o')).rejects.toThrow('HTTP 401');
+  });
+
+  test('throws when OPENROUTER_API_KEY is not set', async () => {
+    delete process.env.OPENROUTER_API_KEY;
+
+    const provider = new OpenRouterProvider();
+
+    await expect(provider.generateResponse('hello', 'openai/gpt-4o')).rejects.toThrow('OPENROUTER_API_KEY not configured');
+  });
+
+  test('uses default max_tokens of 4096 for non-reasoning models', async () => {
+    mockFetchSuccess();
+
+    const provider = new OpenRouterProvider();
+    await provider.generateResponse('hello', 'openai/gpt-4o');
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.max_tokens).toBe(4096);
+  });
+
+  test('uses reasoning max_tokens for reasoning models', async () => {
+    mockFetchSuccess();
+
+    const provider = new OpenRouterProvider();
+    await provider.generateResponse('hello', 'openai/gpt-5-turbo');
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.max_tokens).toBe(16000);
+  });
+
+  test('respects DEFAULT_MAX_TOKENS env var', async () => {
+    process.env.DEFAULT_MAX_TOKENS = '8192';
+    mockFetchSuccess();
+
+    const provider = new OpenRouterProvider();
+    await provider.generateResponse('hello', 'openai/gpt-4o');
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.max_tokens).toBe(8192);
+  });
+
+  test('normalizes model name with prefix when model lacks slash', async () => {
+    mockFetchSuccess();
+
+    const provider = new OpenRouterProvider(undefined, 'openai');
+    await provider.generateResponse('hello', 'gpt-4o');
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.model).toBe('openai/gpt-4o');
+  });
+
+  test('does not double-prefix model name that already contains slash', async () => {
+    mockFetchSuccess();
+
+    const provider = new OpenRouterProvider(undefined, 'openai');
+    await provider.generateResponse('hello', 'openai/gpt-4o');
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.model).toBe('openai/gpt-4o');
+  });
+
+  test('generateResponseWithImage includes image content block', async () => {
+    mockFetchSuccess();
+
+    const provider = new OpenRouterProvider();
+    await provider.generateResponseWithImage('describe this', 'openai/gpt-4o', 'base64data', 'image/png');
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    const content = body.messages[0].content;
+    expect(content).toHaveLength(2);
+    expect(content[1].type).toBe('image_url');
+    expect(content[1].image_url.url).toContain('data:image/png;base64,base64data');
+  });
+
+  test('generateResponseWithImage rejects unsupported image format', async () => {
+    const provider = new OpenRouterProvider();
+
+    await expect(
+      provider.generateResponseWithImage('describe', 'openai/gpt-4o', 'data', 'image/bmp')
+    ).rejects.toThrow('Unsupported image format');
+  });
+
+  test('generateResponseWithAttachments handles mixed image and text', async () => {
+    mockFetchSuccess();
+
+    const provider = new OpenRouterProvider();
+    await provider.generateResponseWithAttachments('analyze', 'openai/gpt-4o', [
+      { type: 'text', content: 'some text', mediaType: 'text/plain' },
+      { type: 'image', content: 'imgdata', mediaType: 'image/jpeg' },
+    ]);
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    const content = body.messages[0].content;
+    expect(content).toHaveLength(3);
+    expect(content[0].type).toBe('text');
+    expect(content[1].type).toBe('text');
+    expect(content[2].type).toBe('image_url');
+  });
+
+  test('request includes abort signal for timeout', async () => {
+    mockFetchSuccess();
+
+    const provider = new OpenRouterProvider();
+    await provider.generateResponse('hello', 'openai/gpt-4o');
+
+    const init = (global.fetch as jest.Mock).mock.calls[0][1];
+    expect(init.signal).toBeDefined();
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('wraps AbortError as timeout error', async () => {
+    const abortError = new DOMException('The operation was aborted', 'AbortError');
+    (global.fetch as jest.Mock).mockRejectedValue(abortError);
+
+    process.env.MODEL_TIMEOUT_MS = '100';
+    const provider = new OpenRouterProvider();
+
+    await expect(provider.generateResponse('hello', 'openai/gpt-4o')).rejects.toThrow('Request timed out');
   });
 });

--- a/ai-node/src/__tests__/lib/llm/provider-config.test.ts
+++ b/ai-node/src/__tests__/lib/llm/provider-config.test.ts
@@ -1,0 +1,68 @@
+import { resolveProviderConfig } from '../../../lib/llm/provider-config';
+
+describe('provider-config precedence', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.AI_GATEWAY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_CLASS_PROVIDER;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.AI_GATEWAY_LEGACY_NATIVE_FALLBACK;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test('defaults to openrouter when OPENROUTER_API_KEY is set', () => {
+    process.env.OPENROUTER_API_KEY = 'or-key';
+
+    const result = resolveProviderConfig('openai');
+
+    expect(result.backend).toBe('openrouter');
+    expect(result.reason).toContain('default openrouter');
+  });
+
+  test('native key present without AI_GATEWAY still routes to openrouter by default', () => {
+    process.env.OPENROUTER_API_KEY = 'or-key';
+    process.env.OPENAI_API_KEY = 'native-key';
+
+    const result = resolveProviderConfig('OpenAI');
+
+    expect(result.backend).toBe('openrouter');
+  });
+
+  test('AI_GATEWAY=native with native key routes to native', () => {
+    process.env.AI_GATEWAY = 'native';
+    process.env.OPENAI_API_KEY = 'native-key';
+
+    const result = resolveProviderConfig('openai');
+
+    expect(result.backend).toBe('native');
+    expect(result.reason).toContain('AI_GATEWAY');
+  });
+
+  test('per-class override takes precedence over global', () => {
+    process.env.AI_GATEWAY = 'openrouter';
+    process.env.OPENAI_CLASS_PROVIDER = 'native';
+
+    const result = resolveProviderConfig('openai');
+
+    expect(result.backend).toBe('native');
+    expect(result.reason).toContain('CLASS_PROVIDER');
+  });
+
+  test('ollama always resolves to native', () => {
+    process.env.AI_GATEWAY = 'openrouter';
+    process.env.OPENROUTER_API_KEY = 'or-key';
+
+    const result = resolveProviderConfig('ollama');
+
+    expect(result.backend).toBe('native');
+    expect(result.reason).toContain('local-only');
+  });
+});

--- a/ai-node/src/__tests__/lib/llm/provider-config.test.ts
+++ b/ai-node/src/__tests__/lib/llm/provider-config.test.ts
@@ -1,4 +1,4 @@
-import { resolveProviderConfig } from '../../../lib/llm/provider-config';
+import { resolveProviderConfig, resolveProviderClass } from '../../../lib/llm/provider-config';
 
 describe('provider-config precedence', () => {
   const ORIGINAL_ENV = process.env;
@@ -10,7 +10,11 @@ describe('provider-config precedence', () => {
     delete process.env.OPENROUTER_API_KEY;
     delete process.env.OPENAI_API_KEY;
     delete process.env.OPENAI_CLASS_PROVIDER;
+    delete process.env.OPENAI_CLASS_MODEL;
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.XAI_API_KEY;
+    delete process.env.GROK_API_KEY;
+    delete process.env.HYPERBOLIC_API_KEY;
     delete process.env.AI_GATEWAY_LEGACY_NATIVE_FALLBACK;
   });
 
@@ -64,5 +68,54 @@ describe('provider-config precedence', () => {
 
     expect(result.backend).toBe('native');
     expect(result.reason).toContain('local-only');
+  });
+
+  test('falls back to native with warning when OPENROUTER_API_KEY missing and native key exists', () => {
+    process.env.OPENAI_API_KEY = 'native-key';
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const result = resolveProviderConfig('openai');
+
+    expect(result.backend).toBe('native');
+    expect(result.reason).toContain('openrouter missing');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('OPENROUTER_API_KEY not set'));
+    warnSpy.mockRestore();
+  });
+
+  test('resolves xai native key via both XAI_API_KEY and GROK_API_KEY', () => {
+    process.env.AI_GATEWAY = 'native';
+    process.env.GROK_API_KEY = 'grok-compat-key';
+
+    const result = resolveProviderConfig('xai');
+
+    expect(result.backend).toBe('native');
+  });
+
+  test('per-class model override is included in resolution', () => {
+    process.env.OPENROUTER_API_KEY = 'or-key';
+    process.env.OPENAI_CLASS_MODEL = 'openai/gpt-5';
+
+    const result = resolveProviderConfig('openai');
+
+    expect(result.modelOverride).toBe('openai/gpt-5');
+  });
+
+  test('unknown provider throws error', () => {
+    expect(() => resolveProviderClass('NonExistentProvider')).toThrow('Unknown provider');
+  });
+
+  test('provider names are case-insensitive', () => {
+    expect(resolveProviderClass('OpenAI')).toBe('openai');
+    expect(resolveProviderClass('ANTHROPIC')).toBe('anthropic');
+    expect(resolveProviderClass('Hyperbolic API')).toBe('hyperbolic');
+    expect(resolveProviderClass('Open-source')).toBe('ollama');
+    expect(resolveProviderClass('Grok')).toBe('xai');
+  });
+
+  test('defaults to openrouter even when no keys are set at all', () => {
+    const result = resolveProviderConfig('openai');
+
+    expect(result.backend).toBe('openrouter');
+    expect(result.reason).toContain('default openrouter');
   });
 });

--- a/ai-node/src/app/api/health/route.ts
+++ b/ai-node/src/app/api/health/route.ts
@@ -1,4 +1,25 @@
 import { NextResponse } from 'next/server';
+import { resolveProviderConfig } from '../../../lib/llm/provider-config';
+
+function buildGatewayStatus() {
+  const classes = ['openai', 'anthropic', 'xai', 'hyperbolic', 'ollama'];
+
+  const routing = classes.map((providerClass) => {
+    const resolution = resolveProviderConfig(providerClass);
+    return {
+      class: providerClass,
+      backend: resolution.backend,
+      model: resolution.modelOverride || null,
+      reason: resolution.reason,
+    };
+  });
+
+  return {
+    mode: process.env.AI_GATEWAY || 'openrouter',
+    openrouterConfigured: !!process.env.OPENROUTER_API_KEY,
+    routing,
+  };
+}
 
 export async function GET() {
   return NextResponse.json({
@@ -7,7 +28,8 @@ export async function GET() {
     service: 'ai-evaluation-service',
     version: process.env.npm_package_version || '1.0.0',
     endpoints: {
-      'rank-and-justify': '/api/rank-and-justify'
-    }
+      'rank-and-justify': '/api/rank-and-justify',
+    },
+    ai_gateway: buildGatewayStatus(),
   });
 }

--- a/ai-node/src/config/openrouter-models.ts
+++ b/ai-node/src/config/openrouter-models.ts
@@ -7,10 +7,25 @@ export const openRouterDefaultModels: Record<Exclude<ProviderClass, 'ollama'>, s
   hyperbolic: 'meta-llama/llama-3.3-70b-instruct',
 };
 
+export const openRouterModelPrefixes: Record<Exclude<ProviderClass, 'ollama'>, string> = {
+  openai: 'openai',
+  anthropic: 'anthropic',
+  xai: 'x-ai',
+  hyperbolic: 'meta-llama',
+};
+
 export function getOpenRouterDefaultModel(providerClass: ProviderClass): string | null {
   if (providerClass === 'ollama') {
     return null;
   }
 
   return openRouterDefaultModels[providerClass];
+}
+
+export function getOpenRouterModelPrefix(providerClass: ProviderClass): string | null {
+  if (providerClass === 'ollama') {
+    return null;
+  }
+
+  return openRouterModelPrefixes[providerClass];
 }

--- a/ai-node/src/config/openrouter-models.ts
+++ b/ai-node/src/config/openrouter-models.ts
@@ -1,0 +1,16 @@
+export type ProviderClass = 'openai' | 'anthropic' | 'xai' | 'hyperbolic' | 'ollama';
+
+export const openRouterDefaultModels: Record<Exclude<ProviderClass, 'ollama'>, string> = {
+  openai: 'openai/gpt-4o',
+  anthropic: 'anthropic/claude-3-5-sonnet-20241022',
+  xai: 'x-ai/grok-4-0709',
+  hyperbolic: 'meta-llama/llama-3.3-70b-instruct',
+};
+
+export function getOpenRouterDefaultModel(providerClass: ProviderClass): string | null {
+  if (providerClass === 'ollama') {
+    return null;
+  }
+
+  return openRouterDefaultModels[providerClass];
+}

--- a/ai-node/src/lib/llm/llm-factory.ts
+++ b/ai-node/src/lib/llm/llm-factory.ts
@@ -6,23 +6,27 @@ import { HyperbolicProvider } from './hyperbolic-provider';
 import { XAIProvider } from './xai-provider';
 import { OpenRouterProvider } from './openrouter-provider';
 import { resolveProviderConfig } from './provider-config';
+import { getOpenRouterModelPrefix } from '../../config/openrouter-models';
 
 export class LLMFactory {
-  static async getProvider(provider: string, classOverride?: string): Promise<LLMProvider> {
-    const providerKey = classOverride || provider;
-    const resolution = resolveProviderConfig(providerKey);
+  static async getProvider(provider: string): Promise<LLMProvider> {
+    const resolution = resolveProviderConfig(provider);
 
     let llmProvider: LLMProvider;
 
     if (resolution.backend === 'openrouter' && resolution.providerClass !== 'ollama') {
       const mappedModel = resolution.modelOverride || 'openai/gpt-4o';
-      llmProvider = new OpenRouterProvider([
-        {
-          name: mappedModel,
-          supportsImages: true,
-          supportsAttachments: true,
-        },
-      ]);
+      const prefix = getOpenRouterModelPrefix(resolution.providerClass) || '';
+      llmProvider = new OpenRouterProvider(
+        [
+          {
+            name: mappedModel,
+            supportsImages: true,
+            supportsAttachments: true,
+          },
+        ],
+        prefix,
+      );
       console.log(`[LLMFactory] Class=${provider} → backend=openrouter model=${mappedModel}`);
     } else {
       switch (provider) {

--- a/ai-node/src/lib/llm/llm-factory.ts
+++ b/ai-node/src/lib/llm/llm-factory.ts
@@ -4,39 +4,59 @@ import { OpenAIProvider } from './openai-provider';
 import { AnthropicProvider } from './anthropic-provider';
 import { HyperbolicProvider } from './hyperbolic-provider';
 import { XAIProvider } from './xai-provider';
+import { OpenRouterProvider } from './openrouter-provider';
+import { resolveProviderConfig } from './provider-config';
 
 export class LLMFactory {
-  static async getProvider(provider: string): Promise<LLMProvider> {
+  static async getProvider(provider: string, classOverride?: string): Promise<LLMProvider> {
+    const providerKey = classOverride || provider;
+    const resolution = resolveProviderConfig(providerKey);
+
     let llmProvider: LLMProvider;
-    switch (provider) {
-      case 'OpenAI':
-      case 'openai':
-        llmProvider = new OpenAIProvider();
-        break;
-      case 'Anthropic':
-      case 'anthropic':
-        llmProvider = new AnthropicProvider();
-        break;
-      case 'Open-source':
-      case 'ollama':
-      case 'Ollama':
-        llmProvider = new OllamaProvider();
-        break;
-      case 'Hyperbolic':
-      case 'hyperbolic':
-      case 'Hyperbolic API':  // ClassID data uses "Hyperbolic API" as provider name
-        llmProvider = new HyperbolicProvider();
-        break;
-      case 'xAI':
-      case 'xai':
-      case 'XAI':
-      case 'Grok':
-      case 'grok':
-        llmProvider = new XAIProvider();
-        break;
-      default:
-        throw new Error(`Unknown provider: ${provider}`);
+
+    if (resolution.backend === 'openrouter' && resolution.providerClass !== 'ollama') {
+      const mappedModel = resolution.modelOverride || 'openai/gpt-4o';
+      llmProvider = new OpenRouterProvider([
+        {
+          name: mappedModel,
+          supportsImages: true,
+          supportsAttachments: true,
+        },
+      ]);
+      console.log(`[LLMFactory] Class=${provider} → backend=openrouter model=${mappedModel}`);
+    } else {
+      switch (provider) {
+        case 'OpenAI':
+        case 'openai':
+          llmProvider = new OpenAIProvider();
+          break;
+        case 'Anthropic':
+        case 'anthropic':
+          llmProvider = new AnthropicProvider();
+          break;
+        case 'Open-source':
+        case 'ollama':
+        case 'Ollama':
+          llmProvider = new OllamaProvider();
+          break;
+        case 'Hyperbolic':
+        case 'hyperbolic':
+        case 'Hyperbolic API':  // ClassID data uses "Hyperbolic API" as provider name
+          llmProvider = new HyperbolicProvider();
+          break;
+        case 'xAI':
+        case 'xai':
+        case 'XAI':
+        case 'Grok':
+        case 'grok':
+          llmProvider = new XAIProvider();
+          break;
+        default:
+          throw new Error(`Unknown provider: ${provider}`);
+      }
+      console.log(`[LLMFactory] Class=${provider} → backend=native`);
     }
+
     await llmProvider.initialize();
     return llmProvider;
   }

--- a/ai-node/src/lib/llm/llm-provider-interface.ts
+++ b/ai-node/src/lib/llm/llm-provider-interface.ts
@@ -25,7 +25,7 @@ export interface LLMProvider {
 
   generateResponseWithImage(prompt: string, model: string, base64Image: string): Promise<string>;
 
-  generateResponseWithAttachments(prompt: string, model: string, attachments: Array<{ type: string, content: string }>, options?: { reasoning?: { effort?: 'low' | 'medium' | 'high' }, verbosity?: 'low' | 'medium' | 'high' }): Promise<string>;
+  generateResponseWithAttachments(prompt: string, model: string, attachments: Array<{ type: string, content: string, mediaType: string }>, options?: { reasoning?: { effort?: 'low' | 'medium' | 'high' }, verbosity?: 'low' | 'medium' | 'high' }): Promise<string>;
 
   supportsImages(model: string): boolean;
 

--- a/ai-node/src/lib/llm/openrouter-provider.ts
+++ b/ai-node/src/lib/llm/openrouter-provider.ts
@@ -1,0 +1,164 @@
+import { LLMProvider } from './llm-provider-interface';
+
+const SUPPORTED_IMAGE_FORMATS = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const MAX_FILE_SIZE = 20 * 1024 * 1024;
+
+export class OpenRouterProvider implements LLMProvider {
+  private apiKey: string;
+  private readonly providerName = 'OpenRouter';
+  private readonly baseUrl: string;
+  private models: Array<{ name: string; supportsImages: boolean; supportsAttachments: boolean }>;
+
+  constructor(models?: Array<{ name: string; supportsImages: boolean; supportsAttachments: boolean }>) {
+    this.apiKey = process.env.OPENROUTER_API_KEY || '';
+    this.baseUrl = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1';
+    this.models = models || [
+      { name: 'openai/gpt-4o', supportsImages: true, supportsAttachments: true },
+    ];
+  }
+
+  async initialize(): Promise<void> {
+    if (!this.apiKey) {
+      console.warn('[OpenRouter] OPENROUTER_API_KEY not set. Provider will fail on request.');
+      return;
+    }
+
+    console.log('[OpenRouter] Provider ready');
+  }
+
+  async getModels(): Promise<Array<{ name: string; supportsImages: boolean; supportsAttachments: boolean }>> {
+    return this.models;
+  }
+
+  supportsImages(model: string): boolean {
+    const modelInfo = this.models.find(m => m.name === model);
+    return modelInfo?.supportsImages ?? true;
+  }
+
+  supportsAttachments(model: string): boolean {
+    const modelInfo = this.models.find(m => m.name === model);
+    return modelInfo?.supportsAttachments ?? true;
+  }
+
+  async generateResponse(
+    prompt: string,
+    model: string,
+    options?: { reasoning?: { effort?: 'low' | 'medium' | 'high' }, verbosity?: 'low' | 'medium' | 'high' }
+  ): Promise<string> {
+    return this.callChatCompletions(prompt, model, [], options);
+  }
+
+  async generateResponseWithImage(prompt: string, model: string, base64Image: string, mediaType: string = 'image/jpeg'): Promise<string> {
+    if (!SUPPORTED_IMAGE_FORMATS.includes(mediaType)) {
+      throw new Error(`[${this.providerName}] Unsupported image format: ${mediaType}`);
+    }
+
+    const approximateFileSize = base64Image.length * 0.75;
+    if (approximateFileSize > MAX_FILE_SIZE) {
+      throw new Error(`[${this.providerName}] Image file size must be under 20 MB.`);
+    }
+
+    return this.callChatCompletions(prompt, model, [
+      {
+        type: 'image_url',
+        image_url: {
+          url: `data:${mediaType};base64,${base64Image}`,
+        },
+      },
+    ]);
+  }
+
+  async generateResponseWithAttachments(
+    prompt: string,
+    model: string,
+    attachments: Array<{ type: string; content: string; mediaType: string }>,
+    options?: { reasoning?: { effort?: 'low' | 'medium' | 'high' }, verbosity?: 'low' | 'medium' | 'high' }
+  ): Promise<string> {
+    const attachmentContent = attachments.map(attachment => {
+      if (attachment.type === 'image') {
+        if (!SUPPORTED_IMAGE_FORMATS.includes(attachment.mediaType)) {
+          throw new Error(`[${this.providerName}] Unsupported image format: ${attachment.mediaType}`);
+        }
+
+        const approximateFileSize = attachment.content.length * 0.75;
+        if (approximateFileSize > MAX_FILE_SIZE) {
+          throw new Error(`[${this.providerName}] Image file size must be under 20 MB.`);
+        }
+
+        return {
+          type: 'image_url',
+          image_url: {
+            url: `data:${attachment.mediaType};base64,${attachment.content}`,
+            detail: 'auto',
+          },
+        };
+      }
+
+      return {
+        type: 'text',
+        text: attachment.content,
+      };
+    });
+
+    return this.callChatCompletions(prompt, model, attachmentContent as any[], options);
+  }
+
+  private async callChatCompletions(
+    prompt: string,
+    model: string,
+    contentBlocks: any[] = [],
+    options?: { reasoning?: { effort?: 'low' | 'medium' | 'high' }, verbosity?: 'low' | 'medium' | 'high' }
+  ): Promise<string> {
+    if (!this.apiKey) {
+      throw new Error('[OpenRouter] OPENROUTER_API_KEY not configured');
+    }
+
+    const payload: any = {
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: prompt }, ...contentBlocks],
+        },
+      ],
+      stream: false,
+      max_tokens: this.isReasoningModel(model)
+        ? parseInt(process.env.REASONING_MODEL_MAX_TOKENS || '16000')
+        : 1000,
+    };
+
+    if (options?.reasoning) {
+      payload.reasoning = options.reasoning;
+    }
+    if (options?.verbosity) {
+      payload.verbosity = options.verbosity;
+    }
+
+    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`[OpenRouter] HTTP ${response.status}: ${errorText}`);
+    }
+
+    const data = await response.json();
+    const content = data?.choices?.[0]?.message?.content;
+    if (!content) {
+      throw new Error('[OpenRouter] Invalid response payload: missing choices[0].message.content');
+    }
+
+    return content;
+  }
+
+  private isReasoningModel(model: string): boolean {
+    const normalized = model.toLowerCase();
+    return normalized.includes('o1') || normalized.includes('o3') || normalized.includes('gpt-5') || normalized.includes('reasoning');
+  }
+}

--- a/ai-node/src/lib/llm/openrouter-provider.ts
+++ b/ai-node/src/lib/llm/openrouter-provider.ts
@@ -7,14 +7,29 @@ export class OpenRouterProvider implements LLMProvider {
   private apiKey: string;
   private readonly providerName = 'OpenRouter';
   private readonly baseUrl: string;
+  private readonly modelPrefix: string;
   private models: Array<{ name: string; supportsImages: boolean; supportsAttachments: boolean }>;
 
-  constructor(models?: Array<{ name: string; supportsImages: boolean; supportsAttachments: boolean }>) {
+  constructor(
+    models?: Array<{ name: string; supportsImages: boolean; supportsAttachments: boolean }>,
+    modelPrefix?: string,
+  ) {
     this.apiKey = process.env.OPENROUTER_API_KEY || '';
     this.baseUrl = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1';
+    this.modelPrefix = modelPrefix || '';
     this.models = models || [
       { name: 'openai/gpt-4o', supportsImages: true, supportsAttachments: true },
     ];
+  }
+
+  private normalizeModelId(model: string): string {
+    if (model.includes('/')) {
+      return model;
+    }
+    if (this.modelPrefix) {
+      return `${this.modelPrefix}/${model}`;
+    }
+    return model;
   }
 
   async initialize(): Promise<void> {
@@ -113,8 +128,12 @@ export class OpenRouterProvider implements LLMProvider {
       throw new Error('[OpenRouter] OPENROUTER_API_KEY not configured');
     }
 
+    const defaultMaxTokens = parseInt(process.env.DEFAULT_MAX_TOKENS || '4096');
+    const reasoningMaxTokens = parseInt(process.env.REASONING_MODEL_MAX_TOKENS || '16000');
+    const normalizedModel = this.normalizeModelId(model);
+
     const payload: any = {
-      model,
+      model: normalizedModel,
       messages: [
         {
           role: 'user',
@@ -122,9 +141,7 @@ export class OpenRouterProvider implements LLMProvider {
         },
       ],
       stream: false,
-      max_tokens: this.isReasoningModel(model)
-        ? parseInt(process.env.REASONING_MODEL_MAX_TOKENS || '16000')
-        : 1000,
+      max_tokens: this.isReasoningModel(normalizedModel) ? reasoningMaxTokens : defaultMaxTokens,
     };
 
     if (options?.reasoning) {
@@ -134,27 +151,41 @@ export class OpenRouterProvider implements LLMProvider {
       payload.verbosity = options.verbosity;
     }
 
-    const response = await fetch(`${this.baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-    });
+    const timeoutMs = parseInt(process.env.MODEL_TIMEOUT_MS || '120000');
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`[OpenRouter] HTTP ${response.status}: ${errorText}`);
+    try {
+      const response = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`[OpenRouter] HTTP ${response.status}: ${errorText}`);
+      }
+
+      const data = await response.json();
+      const content = data?.choices?.[0]?.message?.content;
+      if (!content) {
+        throw new Error('[OpenRouter] Invalid response payload: missing choices[0].message.content');
+      }
+
+      return content;
+    } catch (error: any) {
+      if (error.name === 'AbortError') {
+        throw new Error(`[OpenRouter] Request timed out after ${timeoutMs}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
     }
-
-    const data = await response.json();
-    const content = data?.choices?.[0]?.message?.content;
-    if (!content) {
-      throw new Error('[OpenRouter] Invalid response payload: missing choices[0].message.content');
-    }
-
-    return content;
   }
 
   private isReasoningModel(model: string): boolean {

--- a/ai-node/src/lib/llm/provider-config.ts
+++ b/ai-node/src/lib/llm/provider-config.ts
@@ -1,0 +1,142 @@
+import { ProviderClass, getOpenRouterDefaultModel } from '../../config/openrouter-models';
+
+export type GatewayBackend = 'openrouter' | 'native';
+
+export interface ProviderResolution {
+  providerClass: ProviderClass;
+  backend: GatewayBackend;
+  modelOverride?: string;
+  reason: string;
+}
+
+const CLASS_FROM_PROVIDER: Record<string, ProviderClass> = {
+  openai: 'openai',
+  anthropic: 'anthropic',
+  xai: 'xai',
+  grok: 'xai',
+  hyperbolic: 'hyperbolic',
+  'hyperbolic api': 'hyperbolic',
+  ollama: 'ollama',
+  'open-source': 'ollama',
+};
+
+function normalizeProvider(provider: string): string {
+  return provider.trim().toLowerCase();
+}
+
+export function resolveProviderClass(provider: string): ProviderClass {
+  const normalized = normalizeProvider(provider);
+  const providerClass = CLASS_FROM_PROVIDER[normalized];
+
+  if (!providerClass) {
+    throw new Error(`Unknown provider: ${provider}`);
+  }
+
+  return providerClass;
+}
+
+function hasNativeKey(providerClass: ProviderClass): boolean {
+  switch (providerClass) {
+    case 'openai':
+      return !!process.env.OPENAI_API_KEY;
+    case 'anthropic':
+      return !!process.env.ANTHROPIC_API_KEY;
+    case 'xai':
+      return !!(process.env.XAI_API_KEY || process.env.GROK_API_KEY);
+    case 'hyperbolic':
+      return !!process.env.HYPERBOLIC_API_KEY;
+    case 'ollama':
+      return true;
+    default:
+      return false;
+  }
+}
+
+function readClassOverride(providerClass: ProviderClass): GatewayBackend | null {
+  const value = process.env[`${providerClass.toUpperCase()}_CLASS_PROVIDER`]?.trim().toLowerCase();
+  if (!value) {
+    return null;
+  }
+  if (value === 'openrouter' || value === 'native') {
+    return value;
+  }
+  return null;
+}
+
+function readClassModelOverride(providerClass: ProviderClass): string | undefined {
+  return process.env[`${providerClass.toUpperCase()}_CLASS_MODEL`]?.trim() || undefined;
+}
+
+function readGlobalGateway(): GatewayBackend | null {
+  const value = process.env.AI_GATEWAY?.trim().toLowerCase();
+  if (!value) {
+    return null;
+  }
+  if (value === 'openrouter' || value === 'native') {
+    return value;
+  }
+  return null;
+}
+
+function legacyNativeOptInEnabled(): boolean {
+  const value = process.env.AI_GATEWAY_LEGACY_NATIVE_FALLBACK?.trim().toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+export function resolveProviderConfig(provider: string): ProviderResolution {
+  const providerClass = resolveProviderClass(provider);
+
+  if (providerClass === 'ollama') {
+    return {
+      providerClass,
+      backend: 'native',
+      reason: 'Ollama is local-only',
+    };
+  }
+
+  const classOverride = readClassOverride(providerClass);
+  if (classOverride) {
+    return {
+      providerClass,
+      backend: classOverride,
+      modelOverride: readClassModelOverride(providerClass),
+      reason: `${providerClass.toUpperCase()}_CLASS_PROVIDER override`,
+    };
+  }
+
+  const globalOverride = readGlobalGateway();
+  if (globalOverride) {
+    return {
+      providerClass,
+      backend: globalOverride,
+      modelOverride: readClassModelOverride(providerClass),
+      reason: 'AI_GATEWAY override',
+    };
+  }
+
+  if (legacyNativeOptInEnabled() && hasNativeKey(providerClass)) {
+    return {
+      providerClass,
+      backend: 'native',
+      modelOverride: readClassModelOverride(providerClass),
+      reason: 'legacy native fallback opt-in',
+    };
+  }
+
+  if (!process.env.OPENROUTER_API_KEY && hasNativeKey(providerClass)) {
+    console.warn(`[Gateway] OPENROUTER_API_KEY not set; falling back to native provider for ${providerClass}`);
+    return {
+      providerClass,
+      backend: 'native',
+      modelOverride: readClassModelOverride(providerClass),
+      reason: 'openrouter missing, native key available',
+    };
+  }
+
+  return {
+    providerClass,
+    backend: 'openrouter',
+    modelOverride: readClassModelOverride(providerClass) || getOpenRouterDefaultModel(providerClass) || undefined,
+    reason: 'default openrouter gateway',
+  };
+}

--- a/installer/bin/install-ai-node.sh
+++ b/installer/bin/install-ai-node.sh
@@ -133,6 +133,7 @@ fi
 # Load API keys
 if [ -f "$INSTALLER_DIR/.api_keys" ]; then
     source "$INSTALLER_DIR/.api_keys"
+    echo -e "${BLUE}AI gateway default is OpenRouter. Native provider keys are treated as advanced overrides.${NC}"
 else
     echo -e "${RED}Error: API keys file not found. Please run setup-environment.sh first.${NC}"
     exit 1
@@ -405,6 +406,17 @@ else
 fi
 
 # Update environment file
+if [ -n "$OPENROUTER_API_KEY" ]; then
+    if grep -q "^OPENROUTER_API_KEY=" "$AI_NODE_DIR/.env.local"; then
+        sed -i.bak "s/^OPENROUTER_API_KEY=.*/OPENROUTER_API_KEY=$OPENROUTER_API_KEY/" "$AI_NODE_DIR/.env.local"
+    else
+        echo "OPENROUTER_API_KEY=$OPENROUTER_API_KEY" >> "$AI_NODE_DIR/.env.local"
+    fi
+    echo -e "${GREEN}OpenRouter API Key configured (default gateway).${NC}"
+else
+    echo -e "${YELLOW}WARNING: OpenRouter API Key not provided. Gateway will require explicit native fallback.${NC}"
+fi
+
 if [ -n "$OPENAI_API_KEY" ]; then
     # Check if key already exists in file
     if grep -q "^OPENAI_API_KEY=" "$AI_NODE_DIR/.env.local"; then

--- a/installer/bin/setup-environment.sh
+++ b/installer/bin/setup-environment.sh
@@ -407,45 +407,61 @@ configure_api_keys() {
         source "$INSTALLER_DIR/.env"
     fi
     
-    # OpenAI API Key
-    if [ -z "$OPENAI_API_KEY" ]; then
-        read -p "Enter your OpenAI API Key (leave blank to skip): " OPENAI_API_KEY
+    # Default AI gateway key (OpenRouter)
+    if [ -z "$OPENROUTER_API_KEY" ]; then
+        read -p "Enter your OpenRouter API Key (recommended default): " OPENROUTER_API_KEY
     else
-        read -p "Enter your OpenAI API Key (leave blank to use existing key): " new_key
+        read -p "Enter your OpenRouter API Key (leave blank to use existing key): " new_key
         if [ -n "$new_key" ]; then
-            OPENAI_API_KEY="$new_key"
+            OPENROUTER_API_KEY="$new_key"
         fi
     fi
-    
-    # Anthropic API Key
-    if [ -z "$ANTHROPIC_API_KEY" ]; then
-        read -p "Enter your Anthropic API Key (leave blank to skip): " ANTHROPIC_API_KEY
-    else
-        read -p "Enter your Anthropic API Key (leave blank to use existing key): " new_key
-        if [ -n "$new_key" ]; then
-            ANTHROPIC_API_KEY="$new_key"
+
+    echo ""
+    echo -e "${BLUE}Advanced / Native Provider Overrides (optional)${NC}"
+    echo -e "${YELLOW}Native keys are only used when AI_GATEWAY=native or per-class overrides are set.${NC}"
+
+    if ask_yes_no "Configure native provider API keys now?"; then
+        # OpenAI API Key
+        if [ -z "$OPENAI_API_KEY" ]; then
+            read -p "Enter your OpenAI API Key (leave blank to skip): " OPENAI_API_KEY
+        else
+            read -p "Enter your OpenAI API Key (leave blank to use existing key): " new_key
+            if [ -n "$new_key" ]; then
+                OPENAI_API_KEY="$new_key"
+            fi
         fi
-    fi
-    
-    # Hyperbolic API Key
-    if [ -z "$HYPERBOLIC_API_KEY" ]; then
-        read -p "Enter your Hyperbolic API Key (leave blank to skip): " HYPERBOLIC_API_KEY
-    else
-        read -p "Enter your Hyperbolic API Key (leave blank to use existing key): " new_key
-        if [ -n "$new_key" ]; then
-            HYPERBOLIC_API_KEY="$new_key"
+
+        # Anthropic API Key
+        if [ -z "$ANTHROPIC_API_KEY" ]; then
+            read -p "Enter your Anthropic API Key (leave blank to skip): " ANTHROPIC_API_KEY
+        else
+            read -p "Enter your Anthropic API Key (leave blank to use existing key): " new_key
+            if [ -n "$new_key" ]; then
+                ANTHROPIC_API_KEY="$new_key"
+            fi
         fi
-    fi
-    
-    # xAI API Key (for Grok models)
-    if [ -z "$XAI_API_KEY" ]; then
-        echo -e "${BLUE}xAI provides access to Grok models (grok-4, grok-4.1, etc.) for advanced reasoning.${NC}"
-        echo -e "${BLUE}Get your key at: https://console.x.ai${NC}"
-        read -p "Enter your xAI API Key (leave blank to skip): " XAI_API_KEY
-    else
-        read -p "Enter your xAI API Key (leave blank to use existing key): " new_key
-        if [ -n "$new_key" ]; then
-            XAI_API_KEY="$new_key"
+
+        # Hyperbolic API Key
+        if [ -z "$HYPERBOLIC_API_KEY" ]; then
+            read -p "Enter your Hyperbolic API Key (leave blank to skip): " HYPERBOLIC_API_KEY
+        else
+            read -p "Enter your Hyperbolic API Key (leave blank to use existing key): " new_key
+            if [ -n "$new_key" ]; then
+                HYPERBOLIC_API_KEY="$new_key"
+            fi
+        fi
+
+        # xAI API Key (for Grok models)
+        if [ -z "$XAI_API_KEY" ]; then
+            echo -e "${BLUE}xAI provides access to Grok models (grok-4, grok-4.1, etc.) for advanced reasoning.${NC}"
+            echo -e "${BLUE}Get your key at: https://console.x.ai${NC}"
+            read -p "Enter your xAI API Key (leave blank to skip): " XAI_API_KEY
+        else
+            read -p "Enter your xAI API Key (leave blank to use existing key): " new_key
+            if [ -n "$new_key" ]; then
+                XAI_API_KEY="$new_key"
+            fi
         fi
     fi
     
@@ -625,6 +641,7 @@ configure_api_keys() {
     cat > "$CONFIG_FILE" << EOL
 # Note: GitHub Token is temporarily required while repositories are private
 # GITHUB_TOKEN="$GITHUB_TOKEN" # Removed
+OPENROUTER_API_KEY="$OPENROUTER_API_KEY"
 OPENAI_API_KEY="$OPENAI_API_KEY"
 ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
 HYPERBOLIC_API_KEY="$HYPERBOLIC_API_KEY"

--- a/installer/bin/upgrade-arbiter.sh
+++ b/installer/bin/upgrade-arbiter.sh
@@ -380,7 +380,7 @@ ARBITER_WAS_RUNNING=$ARBITER_RUNNING
 echo
 echo -e "${BLUE}API Key Configuration${NC}"
 echo -e "${YELLOW}Before upgrading, you can add or update your AI provider API keys.${NC}"
-echo -e "${YELLOW}This is useful if you want to enable new providers (like Hyperbolic) or update existing keys.${NC}"
+echo -e "${YELLOW}The default AI gateway is OpenRouter. Native provider keys are optional overrides.${NC}"
 echo
 
 if ask_yes_no "Would you like to review and update your API keys?" "n"; then
@@ -397,13 +397,35 @@ if ask_yes_no "Would you like to review and update your API keys?" "n"; then
     
     echo ""
     echo -e "${BLUE}Current API Key Status:${NC}"
-    [ -n "$OPENAI_API_KEY" ] && echo -e "  ✓ OpenAI API Key: Configured" || echo -e "  ✗ OpenAI API Key: Not configured"
-    [ -n "$ANTHROPIC_API_KEY" ] && echo -e "  ✓ Anthropic API Key: Configured" || echo -e "  ✗ Anthropic API Key: Not configured"
-    [ -n "$HYPERBOLIC_API_KEY" ] && echo -e "  ✓ Hyperbolic API Key: Configured" || echo -e "  ✗ Hyperbolic API Key: Not configured"
-    [ -n "$XAI_API_KEY" ] && echo -e "  ✓ xAI API Key: Configured" || echo -e "  ✗ xAI API Key: Not configured"
+    [ -n "$OPENROUTER_API_KEY" ] && echo -e "  ✓ OpenRouter API Key: Configured (default gateway)" || echo -e "  ✗ OpenRouter API Key: Not configured (default gateway)"
+    [ -n "$OPENAI_API_KEY" ] && echo -e "  ✓ OpenAI API Key: Configured (native override)" || echo -e "  ✗ OpenAI API Key: Not configured (native override)"
+    [ -n "$ANTHROPIC_API_KEY" ] && echo -e "  ✓ Anthropic API Key: Configured (native override)" || echo -e "  ✗ Anthropic API Key: Not configured (native override)"
+    [ -n "$HYPERBOLIC_API_KEY" ] && echo -e "  ✓ Hyperbolic API Key: Configured (native override)" || echo -e "  ✗ Hyperbolic API Key: Not configured (native override)"
+    [ -n "$XAI_API_KEY" ] && echo -e "  ✓ xAI API Key: Configured (native override)" || echo -e "  ✗ xAI API Key: Not configured (native override)"
     [ -n "$INFURA_API_KEY" ] && echo -e "  ✓ Infura API Key: Configured (optional fallback)" || echo -e "  ✗ Infura API Key: Not configured (optional fallback)"
     [ -n "$PINATA_API_KEY" ] && echo -e "  ✓ Pinata JWT: Configured" || echo -e "  ✗ Pinata JWT: Not configured"
     echo ""
+    
+    # OpenRouter API Key (default gateway)
+    echo -e "${BLUE}OpenRouter is the default AI gateway. One key covers all provider classes.${NC}"
+    if [ -n "$OPENROUTER_API_KEY" ]; then
+        if ask_yes_no "Update OpenRouter API Key? (currently configured)" "n"; then
+            read -sp "Enter new OpenRouter API Key: " new_key
+            echo
+            if [ -n "$new_key" ]; then
+                OPENROUTER_API_KEY="$new_key"
+                echo -e "${GREEN}OpenRouter API Key updated.${NC}"
+            fi
+        fi
+    else
+        read -sp "Enter OpenRouter API Key (recommended default): " OPENROUTER_API_KEY
+        echo
+        [ -n "$OPENROUTER_API_KEY" ] && echo -e "${GREEN}OpenRouter API Key added.${NC}"
+    fi
+    
+    echo ""
+    echo -e "${BLUE}Advanced / Native Provider Overrides (optional)${NC}"
+    echo -e "${YELLOW}Native keys are only used when AI_GATEWAY=native or per-class overrides are set.${NC}"
     
     # OpenAI API Key
     if [ -n "$OPENAI_API_KEY" ]; then
@@ -511,6 +533,7 @@ if ask_yes_no "Would you like to review and update your API keys?" "n"; then
     # Save updated keys
     mkdir -p "$TARGET_DIR/installer"
     cat > "$TARGET_DIR/installer/.api_keys" << EOL
+OPENROUTER_API_KEY="$OPENROUTER_API_KEY"
 OPENAI_API_KEY="$OPENAI_API_KEY"
 ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
 HYPERBOLIC_API_KEY="$HYPERBOLIC_API_KEY"
@@ -521,6 +544,7 @@ EOL
     
     # Also update the source installer directory for future upgrades
     cat > "$INSTALLER_DIR/.api_keys" << EOL
+OPENROUTER_API_KEY="$OPENROUTER_API_KEY"
 OPENAI_API_KEY="$OPENAI_API_KEY"
 ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
 HYPERBOLIC_API_KEY="$HYPERBOLIC_API_KEY"
@@ -1192,6 +1216,18 @@ fi
 echo -e "${BLUE}Updating AI Node API keys...${NC}"
 if [ -f "$TARGET_DIR/installer/.api_keys" ]; then
     source "$TARGET_DIR/installer/.api_keys"
+    
+    # Update OpenRouter key (default gateway)
+    if [ -n "$OPENROUTER_API_KEY" ]; then
+        if grep -q "^OPENROUTER_API_KEY=" "$TARGET_AI_NODE/.env.local"; then
+            sed -i.bak "s/^OPENROUTER_API_KEY=.*/OPENROUTER_API_KEY=$OPENROUTER_API_KEY/" "$TARGET_AI_NODE/.env.local"
+        else
+            echo "OPENROUTER_API_KEY=$OPENROUTER_API_KEY" >> "$TARGET_AI_NODE/.env.local"
+        fi
+        echo -e "${GREEN}✓ OpenRouter API Key updated in AI Node (default gateway)${NC}"
+    else
+        echo -e "${YELLOW}⚠ OpenRouter API Key not configured. Gateway will require explicit native fallback.${NC}"
+    fi
     
     # Update OpenAI key
     if [ -n "$OPENAI_API_KEY" ]; then


### PR DESCRIPTION
## Summary

Introduces a provider-agnostic AI gateway abstraction for `ai-node`, making **OpenRouter the default inference backend** for all provider classes. Native providers (OpenAI, Anthropic, xAI, Hyperbolic) are preserved as explicit override paths.

## What changed

- `src/lib/llm/openrouter-provider.ts` — new OpenRouter provider (OpenAI-compatible client, single `OPENROUTER_API_KEY`)
- `src/config/openrouter-models.ts` — per-class default model mappings through OpenRouter
- `src/lib/llm/provider-config.ts` — config precedence layer
- `src/lib/llm/llm-factory.ts` — updated to route via precedence layer
- `src/app/api/health/route.ts` — new `ai_gateway` field showing active backend per class
- Tests: `openrouter-provider.test.ts`, `provider-config.test.ts`, `llm-factory.test.ts`
- Docs: `README.md` AI Gateway section, `.env.local.example`, `MIGRATION.md`, `DESIGN-OPENROUTER-GATEWAY.md`
- Installer: default path asks only for `OPENROUTER_API_KEY`; native keys gated under Advanced

## Config precedence

```
1. Per-class env override (e.g. OPENAI_CLASS_PROVIDER=native)
2. Global AI_GATEWAY env (openrouter | native)
3. Legacy native config with explicit opt-in
4. Default: OpenRouter
```

⚠️ Native API keys present in the environment do **not** auto-activate native mode. Operators must explicitly set `AI_GATEWAY=native` or a per-class override.

## Migration

Existing installs with native keys continue to work unchanged. No action required unless operators want to switch to OpenRouter.

## Testing

Tests require `npm install` in `ai-node/` before running:

```bash
cd ai-node && npm install && npm test
```

Class IDs are unchanged.