### PR TITLE
docs: add Verdikta backlog workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,63 @@
 
 ---
 
+## Verdikta backlog and issue workflow (mandatory)
+
+`verdikta-arbiter` owns the operator-hosted arbiter stack: AI Node, External
+Adapter, Chainlink Node, Arbiter Operator contract, installer, upgrades,
+diagnostics, and operator documentation. Aggregation protocol work belongs in
+`verdikta-dispatcher`; shared ClassID/schema work in `verdikta-common`; and
+application behavior in the relevant application repository.
+
+- Project: [Verdikta Master Backlog](https://github.com/orgs/verdikta/projects/1)
+- Canonical guide: [Backlog and issue workflow](https://github.com/verdikta/verdikta-docs/blob/main/docs/backlog-workflow.md)
+
+Repository issues are the canonical work records. The Project supplies shared
+Status, Readiness, Priority, Size, Area, and roadmap progress. Never duplicate
+an issue merely to make it visible in the Project.
+
+Before starting work:
+
+1. Read the full issue, parent initiative, dependencies, linked PRs, and this
+   repository guide.
+2. Search the repository and organization for duplicate or superseding work.
+3. Confirm the issue belongs here and is present in the Master Backlog.
+4. Confirm `Readiness = Ready`. Resolve missing scope, acceptance criteria,
+   validation, provider/class decisions, or access instead of guessing.
+5. Treat Agent Queue membership as discovery, not authorization. Inspect risk,
+   permissions, and repository instructions before acting.
+6. Assign the implementing GitHub identity when practical and set
+   `Status = In Progress` only when work begins.
+
+During and after work:
+
+- Keep Scope and acceptance criteria aligned with the implementation.
+- Link the PR and use closing syntax only when the PR will satisfy the issue.
+- If blocked, set `Readiness = Blocked`, keep the truthful execution Status,
+  and record the blocker and removal condition.
+- Set `Status = Review` while the deliverable awaits review.
+- Set `Status = Done` and close the issue only after acceptance criteria and
+  validation are complete and accepted. A merged PR alone is insufficient.
+
+When creating or maintaining issues:
+
+- Implementation issues live here. Cross-repository parent initiatives live in
+  `verdikta-roadmap`, use the `initiative` label, and connect through native
+  GitHub sub-issues.
+- Search before creating. New intake begins as `Inbox` + `Needs Triage`.
+- Do not mark work Ready without Goal, Context, testable Acceptance criteria,
+  Validation, and explicit in/out Scope.
+- Priority is Verdikta-wide. Preserve the distinction between Status and
+  Readiness.
+- GitHub Assignee is the owner. Do not add Owner Type, calendar dates, or a
+  duplicate of Verdikta Bounties state.
+- Summarize and obtain approval before bulk issue or Project mutations.
+
+Use **Top Priorities** for the global next-work queue, **Agent Queue** for
+unassigned Ready/Todo discovery, **Execution Board** for active work,
+**Blocked** for intervention, **Roadmap** for initiatives, and **Master
+Backlog** for the complete inventory.
+
 ## 1. What this repo is
 
 A **Verdikta Arbiter** is a self-hostable node that acts as a **decentralized,

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 
 Verdikta-Arbiter is an open-source oracle system that provides AI-powered dispute resolution services on blockchain networks. It combines advanced language models with blockchain infrastructure to deliver fair, transparent, and efficient arbitration.
 
+## Backlog and contribution workflow
+
+Verdikta coordinates work across repositories through the
+[Verdikta Master Backlog](https://github.com/orgs/verdikta/projects/1).
+Humans and automated agents contributing here must read [AGENTS.md](AGENTS.md)
+and the canonical [backlog and issue workflow](https://github.com/verdikta/verdikta-docs/blob/main/docs/backlog-workflow.md)
+before creating, selecting, or changing work items.
+
 ## 🚀 Quick Start
 
 ### For Node Operators


### PR DESCRIPTION
## Summary

- add or extend root `AGENTS.md` with mandatory Verdikta backlog rules
- document this repository's ownership boundary: AI Node, External Adapter, Chainlink Node, operator contract, installer, and operator work
- add a human-facing README link to the Master Backlog and canonical workflow

## Why

Every agent and human contributor touching this repository should know how to find the global queue, distinguish initiatives from implementation issues, assess Ready work, maintain Status versus Readiness, avoid duplicates, link PRs, and close work only after acceptance.

Canonical guide PR: https://github.com/verdikta/verdikta-docs/pull/7

The canonical link targets `verdikta-docs/main`, so the documentation PR should merge before or with this PR.

## Validation

- `git diff --check`
- verified the README points to the root `AGENTS.md`, Master Backlog, and canonical guide
- verified the agent instructions include navigation, intake, Ready criteria, execution, blocking, completion, ownership, and bulk-mutation rules